### PR TITLE
If you make this change, your styles will work in preview mode.

### DIFF
--- a/core/QUBELY.php
+++ b/core/QUBELY.php
@@ -906,7 +906,7 @@ class QUBELY
 		if ($css_save_as == 'filesystem') {
 			add_action('wp_enqueue_scripts', array($this, 'enqueue_block_css_file'));
 		} else {
-			add_action('wp_head', array($this, 'add_block_inline_css'), 100);
+			add_action('enqueue_block_assets', array($this, 'add_block_inline_css'), 100);
 		}
 		// }
 	}


### PR DESCRIPTION
The issue is wp_head only works if the page is published. Using the new `enqueue_block_assets` hook will ensure your styles work in both the front and backend. I've tested over and over again. This is the only change you need to make.  ;)